### PR TITLE
Contrib wrapper to keep connection ESTABLISHED

### DIFF
--- a/fb/request.py
+++ b/fb/request.py
@@ -24,18 +24,18 @@ def get_object_cat1(con, token, cat, kwargs):
         complex functions  maybe added later. 
         """
         req_str = "/"+kwargs['id']+"?"               #/id?
-        req_str+ = "access_token="+token             #/id?@acces_token=......
+        req_str += "access_token="+token             #/id?@acces_token=......
         del kwargs['id']
         
         key = settings.get_object_cat1_param[cat]    #get the param name for the category(single, multiple)
-        req_str+ = "&"+key+"="                       #/id?@acces_token=......key=
+        req_str += "&"+key+"="                       #/id?@acces_token=......key=
         if key in kwargs.keys():
                 length = len( kwargs[key] )
                 for i in range(length):
                         if i == 0:
-                                req_str+ = kwargs[key][i]
+                                req_str +=  kwargs[key][i]
                         else:
-                                req_str+ = ","+kwargs[key][i]        
+                                req_str +=  ","+kwargs[key][i]        
         else:
                 return "Parameter Error"
         

--- a/fb/wiring.py
+++ b/fb/wiring.py
@@ -27,10 +27,27 @@ def send_request(req_cat, con, req_str, kwargs):
                 kwargs = parse.urlencode(kwargs)    #python3x
         except:
                 kwargs = urllib.urlencode(kwargs)   #python2x
-        con.request(req_cat, req_str, kwargs)      #send request to facebook graph
-        res = con.getresponse().read()		   #read response
+        
+        """
+        Wrapper to keep TCP connection ESTABLISHED. Rather the connection go to
+        CLOSE_WAIT and raise errors CannotSendRequest or the server reply with
+        empty and it raise BadStatusLine
+        """        
+        try:
+            con.request(req_cat, req_str, kwargs)      #send request to facebook graph
+        except httplib.CannotSendRequest:
+            con = create()
+            con.request(req_cat, req_str, kwargs)
+
+        try:
+            res = con.getresponse().read()		   #read response
+        except (IOError, httplib.BadStatusLine):
+            con = create()
+            con.request(req_cat, req_str, kwargs) 
+            res = con.getresponse().read()  
+
         t = type(res)
         if type(res) == t:
                 res = bytes.decode(res)
         return json.loads(res)                     #convert the response to python object
- 
+


### PR DESCRIPTION
Hi @blaklites, I did an little adjustment in wiring.py file. The problem was that connection between client and graph.facebook is closed (TCP CLOSE_WAIT state). This require to reconnect with graph server. 

This solution solve the problem as BadStatusLine or CannotSendRequest. 

```
# Simulating problem...
import fb
...
facebook = fb.graph.api(token)
facebook.publish(actions...)
# After seconds or no... 
# ... raise ...
# httplib.BadStatusLine: ''

# This to required a forced new connection
facebook = fb.graph.api(token)
```
